### PR TITLE
Support passing CUDA_ARCHITECTURES, improve README

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,10 +69,10 @@ If you prefer to your (possibly modified) header files, fill the header director
 
 Please check both CUDA 10.x and cuDNN 7.x are installed and versions are correct.
 
-They are not installed to standard paths on most systems. Please add the CUDA library directory to `LIBRARY_PATH` environment variable before building. For example on Ubuntu and CUDA 10.1,
+They are not installed to standard paths on most systems. `darknet-sys` build system reads `CUDA_PATH` (which defaults to `/opt/cuda` if not set) and assumes it can find cuda libraries at `${CUDA_PATH}/lib64`.
 
 ```sh
-env LIBRARY_PATH=/usr/local/cuda-10.1/lib64
+export CUDA_PATH=/usr/local/cuda-10.1
 cargo build --features enable-cuda
 ```
 

--- a/README.md
+++ b/README.md
@@ -69,12 +69,14 @@ If you prefer to your (possibly modified) header files, fill the header director
 
 Please check both CUDA 10.x and cuDNN 7.x are installed and versions are correct.
 
-They are not installed to standard paths on most systems. `darknet-sys` build system reads `CUDA_PATH` (which defaults to `/opt/cuda` if not set) and assumes it can find cuda libraries at `${CUDA_PATH}/lib64`.
+They are not installed to standard paths on most systems. `darknet-sys` build system reads `CUDA_PATH` environment variable (which defaults to `/opt/cuda` if not set) and assumes it can find cuda libraries at `${CUDA_PATH}/lib64`.
 
 ```sh
 export CUDA_PATH=/usr/local/cuda-10.1
 cargo build --features enable-cuda
 ```
+
+You can also set `CUDA_ARCHITECTURES` which is passed to darknet's cmake. It defaults to `Auto`, which auto-detects GPU architecture based on card present in the system during build.
 
 ## License
 

--- a/build.rs
+++ b/build.rs
@@ -243,6 +243,7 @@ fn build_from_source() -> Result<()> {
 fn main() -> Result<()> {
     println!("cargo:rerun-if-env-changed={}", DARKNET_SRC_ENV);
     println!("cargo:rerun-if-env-changed={}", DARKNET_INCLUDE_PATH_ENV);
+    println!("cargo:rerun-if-env-changed={}", CUDA_PATH_ENV);
     println!(
         "cargo:rerun-if-env-changed={}",
         BINDINGS_TARGET_PATH.display()

--- a/build.rs
+++ b/build.rs
@@ -8,6 +8,7 @@ use std::{
 const DARKNET_SRC_ENV: &'static str = "DARKNET_SRC";
 const DARKNET_INCLUDE_PATH_ENV: &'static str = "DARKNET_INCLUDE_PATH";
 const CUDA_PATH_ENV: &'static str = "CUDA_PATH";
+const CUDA_ARCHITECTURES_ENV: &'static str = "CUDA_ARCHITECTURES";
 
 lazy_static::lazy_static! {
     static ref BINDINGS_SRC_PATH: PathBuf = PathBuf::from(env::var("CARGO_MANIFEST_DIR").expect("Failed to get CARGO_MANIFEST_DIR")).join("src").join("bindings.rs");
@@ -174,6 +175,10 @@ where
             "ENABLE_OPENCV",
             if is_opencv_enabled() { "ON" } else { "OFF" },
         )
+        .define(
+            "CUDA_ARCHITECTURES",
+            env::var_os(CUDA_ARCHITECTURES_ENV).unwrap_or_else(|| "Auto".into()),
+        )
         .build();
 
     // link to darknet
@@ -244,6 +249,7 @@ fn main() -> Result<()> {
     println!("cargo:rerun-if-env-changed={}", DARKNET_SRC_ENV);
     println!("cargo:rerun-if-env-changed={}", DARKNET_INCLUDE_PATH_ENV);
     println!("cargo:rerun-if-env-changed={}", CUDA_PATH_ENV);
+    println!("cargo:rerun-if-env-changed={}", CUDA_ARCHITECTURES_ENV);
     println!(
         "cargo:rerun-if-env-changed={}",
         BINDINGS_TARGET_PATH.display()


### PR DESCRIPTION
### Fix README entry about cuda-related environment variables

I have not found `LIBRARY_PATH` being read anywhere in darknet-sys-rust or in darknet itself.
This reflects changes made in alianse777/darknet-sys-rust#11 and alianse777/darknet-sys-rust#12.

Also add CUDA_PATH to cargo:rerun-if-env-changed.

### Support passing CUDA_ARCHITECTURES to darknet's cmake

Allows to make the build independent on GPU present in the system during build.

---
This PR is based on alianse777/darknet-sys-rust#12. It can be merged either to @skywhale's `cuda-libs` branch, or if alianse777/darknet-sys-rust#12 is merged first I'll change base to upstream master.